### PR TITLE
Add default agent and background recorder modules

### DIFF
--- a/bg_record.py
+++ b/bg_record.py
@@ -1,0 +1,152 @@
+"""Utility hooks used by :mod:`atari_learner` for lightweight monitoring.
+
+The original demo streamed video/metric dashboards by delegating to an external
+``bg_record`` module.  To keep this repository self-contained we provide a very
+small implementation that focuses on metrics:
+
+* Environment threads call :func:`bind_logger`, :func:`log_step` and
+  :func:`log_close` to update a shared statistics tensor and to emit the
+  occasional textual summary.
+* A dedicated background process launched by ``atari_learner.py`` periodically
+  polls the tensors and prints aggregated diagnostics.
+
+The goal is to offer sensible default behaviour without pulling in heavy video
+dependencies.  Users wishing to capture actual gameplay footage can replace
+this module with their own recorder.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+import torch
+
+__all__ = [
+    "bind_logger",
+    "log_step",
+    "log_close",
+    "bg_record_proc",
+]
+
+
+@dataclass
+class _ThreadRecorderState:
+    """Per-thread state updated by :func:`log_step`.
+
+    ``info_tensor`` is a shared CUDA tensor with four statistics per environment:
+    cumulative reward, frame count, terminated flag, and truncated flag.  The
+    tensor is written to directly so that the learner can consume the data
+    without any additional synchronisation primitives.
+    """
+
+    game_id: str
+    env_index: int
+    info_tensor: torch.Tensor
+    episode_reward: float = 0.0
+    frame_count: int = 0
+    episodes_completed: int = 0
+    last_print_ts: float = field(default_factory=time.time)
+
+    def tensor_row(self) -> torch.Tensor:
+        return self.info_tensor[self.env_index]
+
+
+_THREAD_STATE = threading.local()
+
+
+def bind_logger(game_id: str, env_index: int, info_tensor: torch.Tensor) -> None:
+    """Attach the global logging helpers to an environment worker thread."""
+
+    _THREAD_STATE.state = _ThreadRecorderState(game_id=game_id, env_index=env_index, info_tensor=info_tensor)
+
+
+def log_step(action: int, obs, reward: float, terminated: bool, truncated: bool) -> None:
+    """Update counters after every environment step.
+
+    ``obs`` is accepted for API compatibility, but we do not process it in the
+    reference implementation.  The helper focuses on maintaining ``info_tensor``
+    so that the agent can react to termination signals and observe rewards.
+    """
+
+    state: Optional[_ThreadRecorderState] = getattr(_THREAD_STATE, "state", None)
+    if state is None:
+        return
+
+    state.episode_reward += float(reward)
+    state.frame_count += 1
+
+    # ``info_tensor`` lives on the GPU.  Assigning to individual elements is
+    # safe from CPU threads and keeps everything device-resident.
+    row = state.tensor_row()
+    row[0] = state.episode_reward
+    row[1] = float(state.frame_count)
+    row[2] = 1.0 if terminated else 0.0
+    row[3] = 1.0 if truncated else 0.0
+
+    if terminated or truncated:
+        state.episodes_completed += 1
+        now = time.time()
+        if now - state.last_print_ts > 15.0:
+            print(
+                f"[{state.game_id} | env {state.env_index}] episodes={state.episodes_completed} "
+                f"last_reward={state.episode_reward:.1f} last_length={state.frame_count}"
+            )
+            state.last_print_ts = now
+        state.episode_reward = 0.0
+        state.frame_count = 0
+
+
+def log_close() -> None:
+    """Clean up thread-local state when an environment is shutting down."""
+
+    if hasattr(_THREAD_STATE, "state"):
+        delattr(_THREAD_STATE, "state")
+
+
+def bg_record_proc(obs_tensor, info_tensor, shutdown_event, game_list, start_time):
+    """Background process that periodically prints aggregate statistics."""
+
+    print("[bg_record] background recorder online – collecting metrics")
+    num_envs = info_tensor.shape[0]
+    last_report = 0.0
+
+    # Store the best (highest) cumulative reward seen for each environment.
+    best_rewards: Dict[int, float] = {i: float("-inf") for i in range(num_envs)}
+
+    while not shutdown_event.is_set():
+        time.sleep(10.0)
+        snapshot = info_tensor.clone().detach().to("cpu")
+
+        cumulative_rewards = snapshot[:, 0]
+        frame_counts = snapshot[:, 1]
+        terminated_flags = snapshot[:, 2]
+        truncated_flags = snapshot[:, 3]
+
+        # Track best reward per environment.
+        for idx, reward in enumerate(cumulative_rewards.tolist()):
+            if reward > best_rewards[idx]:
+                best_rewards[idx] = reward
+
+        elapsed = time.time() - start_time
+        if elapsed - last_report < 10.0:
+            continue
+
+        last_report = elapsed
+        running_envs = int(((terminated_flags + truncated_flags) == 0).sum().item())
+        avg_reward = float(cumulative_rewards.mean().item()) if num_envs else 0.0
+        avg_length = float(frame_counts.mean().item()) if num_envs else 0.0
+        print(
+            f"[bg_record] t={elapsed:7.1f}s | envs={num_envs} | running={running_envs} "
+            f"| avg_reward={avg_reward:7.2f} | avg_length={avg_length:7.1f}"
+        )
+
+    print("[bg_record] shutdown requested – final metrics:")
+    for idx, best in best_rewards.items():
+        game_name = game_list[idx] if idx < len(game_list) else f"env_{idx}"
+        if best == float("-inf"):
+            continue
+        print(f"  • {game_name}: best_cumulative_reward={best:.1f}")
+

--- a/myagent.py
+++ b/myagent.py
@@ -1,0 +1,127 @@
+"""Reference implementation of the :class:`Agent` API expected by ``atari_learner``.
+
+This module provides a very small, self-contained agent that keeps track of a
+handful of statistics and issues random actions.  The goal is not to provide a
+competitive learner, but rather to ship a ready-to-run scaffold that exercises
+the multiprocessing/data sharing paths in ``atari_learner.py``.  Advanced users
+are encouraged to replace this file with their own agent implementation.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass
+class AgentState:
+    """Container for the lightweight state that we persist to disk."""
+
+    total_steps: int = 0
+    episodes_seen: int = 0
+
+
+class Agent:
+    """Minimal agent used for bootstrapping the Atari learner runner.
+
+    The runner shares three CUDA tensors with this class:
+
+    ``obs_tensor``
+        ``(num_envs, H, W, C)`` tensor containing the latest RGB observation for
+        every tracked environment.
+
+    ``info_tensor``
+        ``(num_envs, 4)`` tensor with per-environment statistics formatted as
+        ``(cumulative_reward, frame_count, terminated_flag, truncated_flag)``.
+
+    ``action_tensor``
+        ``(num_envs,)`` tensor where the agent must write the next action to
+        execute.  All environments are created with ``full_action_space=True`` so
+        the valid action range is ``[0, 18)``.
+
+    The reference implementation keeps the tensors on the GPU (matching the
+    expectations of ``atari_learner.py``) and simply issues random actions.  The
+    bookkeeping makes it easy to swap in a proper learner at a later point.
+    """
+
+    #: Maximum number of actions in the Atari full action space.
+    MAX_ACTIONS: int = 18
+
+    def __init__(self) -> None:
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.state = AgentState()
+        # Torch random generator dedicated to action sampling.  Using a manual
+        # generator keeps the behaviour deterministic with respect to seeding in
+        # ``atari_learner.py``.
+        self._rng = torch.Generator(device=self.device)
+
+        # ``atari_learner`` seeds the global PyTorch RNG, therefore copying the
+        # current seed keeps everything reproducible.
+        self._rng.manual_seed(torch.initial_seed())
+
+        # Buffers that will be lazily initialised on the correct device on first
+        # use.  They are reused on every call to avoid repeated allocations.
+        self._action_buffer: Optional[torch.Tensor] = None
+
+    # ------------------------------------------------------------------
+    # Public API expected by ``atari_learner``
+    # ------------------------------------------------------------------
+    def act_and_learn(
+        self, obs_tensor: torch.Tensor, info_tensor: torch.Tensor, action_tensor: torch.Tensor
+    ) -> None:
+        """Read the latest environment data and emit actions.
+
+        The default implementation samples uniformly from the full action space
+        and keeps track of a few diagnostic counters.  The tensors already live
+        on the GPU so all operations happen in-place without device transfers.
+        """
+
+        num_envs = obs_tensor.shape[0]
+
+        if self._action_buffer is None or self._action_buffer.shape[0] != num_envs:
+            self._action_buffer = torch.empty(num_envs, device=self.device, dtype=torch.float32)
+
+        # Sample a random action for every environment.  ``torch.randint`` is not
+        # generator-aware prior to PyTorch 2.3, therefore we sample uniform random
+        # numbers and quantise them to the [0, MAX_ACTIONS) range.
+        self._action_buffer.uniform_(0.0, float(self.MAX_ACTIONS), generator=self._rng)
+        actions = self._action_buffer.to(dtype=torch.int64)
+
+        # Update basic statistics from ``info_tensor``.  Keeping them on the
+        # agent side makes it trivial to extend the class into a real learner.
+        with torch.no_grad():
+            info_view = info_tensor[:, :2]
+            if info_view.numel() > 0:
+                frame_counts = info_view[:, 1]
+                self.state.total_steps += int(frame_counts.sum().item())
+
+        action_tensor.copy_(actions)
+
+    def save(self, path: str) -> None:
+        """Persist lightweight agent state to ``path``.
+
+        Only a few counters are stored; the expectation is that real agents will
+        extend this to include neural network weights, optimiser states, etc.
+        """
+
+        directory = os.path.dirname(os.path.abspath(path))
+        if directory and not os.path.exists(directory):
+            os.makedirs(directory, exist_ok=True)
+
+        torch.save(self.state.__dict__, path)
+
+    def load(self, path: str) -> None:
+        """Load previously persisted state from ``path`` if it exists."""
+
+        if not os.path.exists(path):
+            raise FileNotFoundError(path)
+
+        payload = torch.load(path, map_location="cpu")
+        if not isinstance(payload, dict):
+            raise ValueError(f"Unexpected checkpoint format in {path!r}")
+
+        self.state = AgentState(**payload)
+


### PR DESCRIPTION
## Summary
- add a reference `Agent` implementation that samples random Atari actions while keeping basic counters and handling checkpoint IO
- implement a lightweight `bg_record` module that writes per-environment statistics to the shared tensors and prints aggregate metrics from a background process

## Testing
- `python -m compileall .`


------
https://chatgpt.com/codex/tasks/task_e_68d1f7548c188323b65286b8f2448b93