### PR TITLE
Add CLI controls for single-game CPU runs

### DIFF
--- a/atari_learner.py
+++ b/atari_learner.py
@@ -1,18 +1,38 @@
 #!/usr/bin/env python3
-import torch, gymnasium as gym, numpy as np, time, sys, threading, os, random
+"""Entry point for launching the multi-environment Atari runner.
+
+The original viral demo by ``@actualhog`` launched the full suite of 57 Atari
+titles simultaneously on a powerful GPU.  This script keeps that ability while
+also exposing a couple of quality-of-life flags so that the runner can be used
+on more modest hardware (for example, running a single environment on a CPU
+only Mac).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import sys
+import threading
+import time
+from typing import List, Sequence
+
+import gymnasium as gym
+import numpy as np
+import torch
 import torch.multiprocessing as mp
 from torch import Tensor
 
-from bg_record import log_step, bind_logger, log_close
+from bg_record import bind_logger, log_close, log_step
 
 # torch.set_num_threads(1)
 
-NUM_PROCS = 16
-FPS = 60.0
+DEFAULT_NUM_PROCS = 16
+DEFAULT_FPS = 60.0
 MAX_ACTIONS = 18
-MAX_EPISODE_STEPS = int(45 * 60 * FPS)
 
-games = sorted([
+ALL_GAMES: Sequence[str] = sorted([
     "ALE/Adventure-v5", "ALE/AirRaid-v5", "ALE/Alien-v5", "ALE/Amidar-v5", "ALE/Assault-v5",
     "ALE/Asterix-v5", "ALE/Asteroids-v5", "ALE/Atlantis-v5", "ALE/BankHeist-v5",
     "ALE/BattleZone-v5", "ALE/BeamRider-v5", "ALE/Berzerk-v5", "ALE/Bowling-v5",
@@ -30,13 +50,126 @@ games = sorted([
     "ALE/Venture-v5", "ALE/VideoPinball-v5", "ALE/WizardOfWor-v5", "ALE/YarsRevenge-v5",
     "ALE/Zaxxon-v5"
 ])
-NUM_ENVS = len(games)
-print(f'{NUM_ENVS=}')
 
-def env_thread_worker(first_start_at, game_id, g_idx, obs_s: Tensor, act_s: Tensor, info_s: Tensor, shutdown):
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse command line arguments used to customise the runner."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--game",
+        help=(
+            "Run a single Gymnasium environment instead of the full 57-game suite. "
+            "Mutually exclusive with --games."
+        ),
+    )
+    parser.add_argument(
+        "--games",
+        nargs="+",
+        metavar="ENV_ID",
+        help="Explicit list of Gymnasium environment IDs to launch.",
+    )
+    parser.add_argument(
+        "--num-procs",
+        type=int,
+        default=None,
+        help=(
+            "Number of environment worker processes to spawn.  Defaults to min(16, number of environments)."
+        ),
+    )
+    parser.add_argument(
+        "--device",
+        choices=("auto", "cuda", "cpu"),
+        default="auto",
+        help=(
+            "Device used for the shared tensors.  'auto' selects CUDA when available "
+            "and falls back to CPU otherwise."
+        ),
+    )
+    parser.add_argument(
+        "--start-method",
+        choices=sorted(mp.get_all_start_methods()),
+        default=None,
+        help=(
+            "Multiprocessing start method.  Defaults to 'forkserver' on Linux and 'spawn' on macOS."
+        ),
+    )
+    parser.add_argument(
+        "--fps",
+        type=float,
+        default=DEFAULT_FPS,
+        help="Target frames per second per environment (default: 60).",
+    )
+    parser.add_argument(
+        "--max-episode-steps",
+        type=int,
+        default=None,
+        help=(
+            "Maximum steps per episode passed to Gymnasium.  Defaults to 45 minutes worth of frames "
+            "at the selected FPS."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.game and args.games:
+        parser.error("--game and --games are mutually exclusive")
+
+    return args
+
+
+def resolve_games(args: argparse.Namespace) -> List[str]:
+    """Return the ordered list of environments to launch based on CLI flags."""
+
+    if args.game:
+        return [args.game]
+    if args.games:
+        return list(dict.fromkeys(args.games))  # Preserve order while removing duplicates.
+    return list(ALL_GAMES)
+
+
+def resolve_device(device_flag: str) -> torch.device:
+    """Map a device flag to an actual :class:`torch.device`."""
+
+    if device_flag == "auto":
+        device_flag = "cuda" if torch.cuda.is_available() else "cpu"
+    if device_flag == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but is not available.")
+    return torch.device(device_flag)
+
+
+def select_start_method(start_method_flag: str | None) -> str:
+    """Pick an appropriate multiprocessing start method."""
+
+    if start_method_flag:
+        return start_method_flag
+    if sys.platform == "darwin":
+        # Fork-based start methods are not recommended on macOS when interacting with
+        # Cocoa or Metal (common on Apple Silicon laptops).
+        return "spawn"
+    return "forkserver"
+
+
+def env_thread_worker(
+    first_start_at: float,
+    game_id: str,
+    g_idx: int,
+    obs_s: Tensor,
+    act_s: Tensor,
+    info_s: Tensor,
+    shutdown,
+    fps: float,
+    max_episode_steps: int,
+):
     import ale_py # required for atari
     next_frame_due = first_start_at + 15.0 # let all procs start
-    env = gym.make(game_id, obs_type="rgb", frameskip=1, repeat_action_probability=0.0, full_action_space=True, max_episode_steps=MAX_EPISODE_STEPS)
+    env = gym.make(
+        game_id,
+        obs_type="rgb",
+        frameskip=1,
+        repeat_action_probability=0.0,
+        full_action_space=True,
+        max_episode_steps=max_episode_steps,
+    )
     envseed = g_idx * 100 + int(os.environ['myseed'])
     print(f'{game_id=} {envseed=}')
     obs, _ = env.reset(seed=envseed)
@@ -44,7 +177,8 @@ def env_thread_worker(first_start_at, game_id, g_idx, obs_s: Tensor, act_s: Tens
     obs_s[g_idx, :h, :w].copy_(torch.from_numpy(obs), non_blocking=True)
     bind_logger(game_id, g_idx, info_s)
     while not shutdown.is_set():
-        while time.time() > next_frame_due: next_frame_due += 1.0 / FPS
+        while time.time() > next_frame_due:
+            next_frame_due += 1.0 / fps
         time.sleep(max(0, next_frame_due - time.time()))
         action = act_s[g_idx].item()
         obs, rew, term, trunc, _ = env.step(action)
@@ -60,14 +194,21 @@ def seed(prefix, offset:int):
     random.seed(s)
     np.random.seed(s)
     torch.manual_seed(s)
-    torch.cuda.manual_seed(s)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(s)
     # torch.backends.cudnn.deterministic = True # Not worth it!
     # torch.backends.cudnn.benchmark = False # Not worth it!
 
-def env_proc(first_start_at, game_chunk, offset, obs_s, act_s, info_s, shutdown):
+
+def env_proc(first_start_at, game_chunk, offset, obs_s, act_s, info_s, shutdown, fps, max_episode_steps):
     seed('env', offset + 1)
-    threads = [threading.Thread(target=env_thread_worker, args=(first_start_at, g, offset+i, obs_s, act_s, info_s, shutdown))
-               for i, g in enumerate(game_chunk)]
+    threads = [
+        threading.Thread(
+            target=env_thread_worker,
+            args=(first_start_at, g, offset + i, obs_s, act_s, info_s, shutdown, fps, max_episode_steps),
+        )
+        for i, g in enumerate(game_chunk)
+    ]
     for t in threads: t.start()
     for t in threads: t.join()
 
@@ -100,27 +241,59 @@ def agent_proc(obs_s, act_s, info_s, shutdown):
             agent.load(save_path)
             last_save_time = time.time()
 
-if __name__ == "__main__":
-    first_start_at = time.time()
-    mp.set_start_method("forkserver", force=True)
-    obs_s = torch.zeros((NUM_ENVS, 250, 160, 3), dtype=torch.uint8, device="cuda").share_memory_()
-    act_s = torch.zeros(NUM_ENVS, dtype=torch.int64, device="cuda").share_memory_()
-    info_s = torch.zeros((NUM_ENVS, 4), dtype=torch.float32, device="cuda").share_memory_()
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv or sys.argv[1:])
+
+    selected_games = resolve_games(args)
+    if not selected_games:
+        raise ValueError("No environments selected – specify at least one via --game/--games.")
+
+    max_episode_steps = args.max_episode_steps
+    if max_episode_steps is None:
+        max_episode_steps = int(45 * 60 * args.fps)
+
+    device = resolve_device(args.device)
+    start_method = select_start_method(args.start_method)
+    mp.set_start_method(start_method, force=True)
+
+    num_envs = len(selected_games)
+    print(f"Selected {num_envs} environment(s): {', '.join(selected_games)}")
+    print(f"Using device={device} | start_method={start_method} | fps={args.fps} | max_episode_steps={max_episode_steps}")
+
+    obs_s = torch.zeros((num_envs, 250, 160, 3), dtype=torch.uint8, device=device).share_memory_()
+    act_s = torch.zeros(num_envs, dtype=torch.int64, device=device).share_memory_()
+    info_s = torch.zeros((num_envs, 4), dtype=torch.float32, device=device).share_memory_()
     shutdown = mp.Event()
 
     proc_configs = [{'target': agent_proc, 'args': (obs_s, act_s, info_s, shutdown)}]
-    game_chunks = np.array_split(games, NUM_PROCS)
+
+    num_procs = args.num_procs or min(DEFAULT_NUM_PROCS, num_envs)
+    num_procs = max(1, num_procs)
+    # ``np.array_split`` keeps the ordering of ``selected_games`` while distributing
+    # them roughly evenly across worker processes.
+    raw_chunks = np.array_split(selected_games, num_procs)
+    game_chunks: List[List[str]] = [list(chunk) for chunk in raw_chunks if len(chunk) > 0]
+
+    first_start_at = time.time()
     for i, chunk in enumerate(game_chunks):
         offset = sum(len(c) for c in game_chunks[:i])
-        proc_configs.append({'target': env_proc, 'args': (first_start_at, chunk, offset, obs_s, act_s, info_s, shutdown)})
+        proc_configs.append(
+            {
+                'target': env_proc,
+                'args': (first_start_at, chunk, offset, obs_s, act_s, info_s, shutdown, args.fps, max_episode_steps),
+            }
+        )
 
-    # bg_record_proc(obs_s, shutdown, out_path="12x6_1080_30.mp4")
     from bg_record import bg_record_proc
-    proc_configs.append({'target': bg_record_proc, 'args': (obs_s, info_s, shutdown, games, first_start_at)})
+
+    proc_configs.append({'target': bg_record_proc, 'args': (obs_s, info_s, shutdown, selected_games, first_start_at)})
 
     procs = [mp.Process(**cfg) for cfg in proc_configs]
 
-    for p in procs: p.start()
+    for p in procs:
+        p.start()
+
     try:
         duration = int(os.environ["RUNDURATIONSECONDS"])
         while time.time() - first_start_at < duration:
@@ -135,9 +308,15 @@ if __name__ == "__main__":
         print("\nShutdown signal received...")
     finally:
         shutdown.set()
-        for p in procs: p.join(timeout=10)
         for p in procs:
-            if p.is_alive(): p.terminate()
+            p.join(timeout=10)
+        for p in procs:
+            if p.is_alive():
+                p.terminate()
         print("All processes terminated.")
+
+
+if __name__ == "__main__":
+    main()
 
 # agent ranking code has moved but essentially you want your top few episodes to score within 50% of the all-time record on each and every game. especially adventure, pong, pitfall, and skiing. nobody willing to face the pain with skiing... so much pain in that game lol

--- a/bg_record.py
+++ b/bg_record.py
@@ -36,10 +36,10 @@ __all__ = [
 class _ThreadRecorderState:
     """Per-thread state updated by :func:`log_step`.
 
-    ``info_tensor`` is a shared CUDA tensor with four statistics per environment:
-    cumulative reward, frame count, terminated flag, and truncated flag.  The
-    tensor is written to directly so that the learner can consume the data
-    without any additional synchronisation primitives.
+    ``info_tensor`` is a shared tensor (CPU or CUDA) with four statistics per
+    environment: cumulative reward, frame count, terminated flag, and truncated
+    flag.  The tensor is written to directly so that the learner can consume the
+    data without any additional synchronisation primitives.
     """
 
     game_id: str
@@ -78,8 +78,9 @@ def log_step(action: int, obs, reward: float, terminated: bool, truncated: bool)
     state.episode_reward += float(reward)
     state.frame_count += 1
 
-    # ``info_tensor`` lives on the GPU.  Assigning to individual elements is
-    # safe from CPU threads and keeps everything device-resident.
+    # ``info_tensor`` can live on either the CPU or GPU.  Assigning to
+    # individual elements is safe from CPU threads and keeps everything
+    # device-resident.
     row = state.tensor_row()
     row[0] = state.episode_reward
     row[1] = float(state.frame_count)


### PR DESCRIPTION
## Summary
- add command-line options to select games, device, FPS, and multiprocessing start method in `atari_learner.py`
- enable CPU-only execution and update the background recorder docs to reflect device-agnostic tensors
- refresh the README with single-game examples, CLI flag reference, and macOS/CPU guidance

## Testing
- python -m compileall atari_learner.py bg_record.py myagent.py
- python atari_learner.py --help *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68d1fc070c908323a7a2055b7e26fe94