### PR TITLE
Add CLI flag for launching multiple instances per game

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ python atari_learner.py --game ALE/Pong-v5 --device cpu --num-procs 1
 The `--game` flag selects one Atari title, while `--num-procs 1` keeps the
 process count low so the run fits comfortably on a MacBook.
 
+Want to saturate a CPU-only machine with multiple copies of the same title?
+Add `--instances-per-game 10` (or any positive integer) to replicate each
+selected game.  Combined with `--show-viewer` the Tkinter window tiles every
+instance so you can watch them side by side:
+
+```bash
+python atari_learner.py --game ALE/Pong-v5 --device cpu --instances-per-game 10 --show-viewer
+```
+
+By default the runner spawns up to one worker process per environment (capped
+at 16 unless you override `--num-procs`), keeping each instance isolated and
+matching the viewer layout.
+
 ---
 
 ## 6. Running the Suite
@@ -209,6 +222,7 @@ process count low so the run fits comfortably on a MacBook.
    * **Full suite:** run `python atari_learner.py` with no extra flags.
    * **Single environment:** add `--game ALE/Pong-v5` (or any other ID from the Gymnasium registry).
    * **Custom list:** provide multiple IDs with `--games ALE/Pong-v5 ALE/Breakout-v5`.
+   * **Multiple copies per game:** append `--instances-per-game 10` to run ten instances of each selected title in parallel.
 3. Pick a device with `--device {auto,cuda,cpu}`.  The default `auto` uses CUDA when available and falls back to CPU otherwise.
 4. (Optional) Tune parallelism with `--num-procs` and the frame rate with `--fps`/`--max-episode-steps`.  These replace the manual edits that were previously required.
 5. Launch the runner.  For example, to run Pong and Breakout on the CPU:
@@ -246,6 +260,7 @@ The runner exposes a handful of switches so you can tailor it to the hardware yo
 | `--games ...` | Provide an explicit list of Gymnasium environment IDs to run simultaneously. |
 | `--device {auto,cuda,cpu}` | Choose where the shared tensors live.  `auto` prefers CUDA when available. |
 | `--num-procs N` | Number of environment worker processes.  Defaults to `min(16, number of environments)`. |
+| `--instances-per-game 4` | Replicate each selected title the specified number of times (defaults to 1). |
 | `--fps 30` | Target frame rate per environment. |
 | `--max-episode-steps 10000` | Override the maximum episode length passed to Gymnasium. |
 | `--start-method spawn` | Force a specific multiprocessing start method (Linux defaults to `forkserver`, macOS to `spawn`). |

--- a/atari_learner.py
+++ b/atari_learner.py
@@ -96,6 +96,15 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--instances-per-game",
+        type=int,
+        default=1,
+        help=(
+            "Number of parallel instances to launch for each selected game.  "
+            "Useful on CPU-only hardware to run multiple copies of the same title."
+        ),
+    )
+    parser.add_argument(
         "--fps",
         type=float,
         default=DEFAULT_FPS,
@@ -156,17 +165,39 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     if args.game and args.games:
         parser.error("--game and --games are mutually exclusive")
 
+    if args.instances_per_game < 1:
+        parser.error("--instances-per-game must be a positive integer")
+
     return args
 
 
-def resolve_games(args: argparse.Namespace) -> List[str]:
-    """Return the ordered list of environments to launch based on CLI flags."""
+def resolve_games(args: argparse.Namespace) -> tuple[List[str], List[str]]:
+    """Return the ordered list of environments and display names to launch."""
 
     if args.game:
-        return [args.game]
-    if args.games:
-        return list(dict.fromkeys(args.games))  # Preserve order while removing duplicates.
-    return list(ALL_GAMES)
+        base_games = [args.game]
+    elif args.games:
+        base_games = list(dict.fromkeys(args.games))  # Preserve order while removing duplicates.
+    else:
+        base_games = list(ALL_GAMES)
+
+    instances = max(1, int(args.instances_per_game))
+    expanded: List[str] = []
+    display_names: List[str] = []
+    use_suffixes = instances > 1 or len(base_games) != len(set(base_games))
+    instance_counters: dict[str, int] = {}
+
+    for game in base_games:
+        for _ in range(instances):
+            expanded.append(game)
+            count = instance_counters.get(game, 0) + 1
+            instance_counters[game] = count
+            if use_suffixes:
+                display_names.append(f"{game} #{count}")
+            else:
+                display_names.append(game)
+
+    return expanded, display_names
 
 
 def resolve_device(device_flag: str) -> torch.device:
@@ -194,6 +225,7 @@ def select_start_method(start_method_flag: str | None) -> str:
 def env_thread_worker(
     first_start_at: float,
     game_id: str,
+    display_name: str,
     g_idx: int,
     obs_s: Tensor,
     act_s: Tensor,
@@ -213,11 +245,11 @@ def env_thread_worker(
         max_episode_steps=max_episode_steps,
     )
     envseed = g_idx * 100 + int(os.environ['myseed'])
-    print(f'{game_id=} {envseed=}')
+    print(f"env_index={g_idx} game_id={game_id} display_name={display_name!r} envseed={envseed}")
     obs, _ = env.reset(seed=envseed)
     h, w, _ = obs.shape
     obs_s[g_idx, :h, :w].copy_(torch.from_numpy(obs), non_blocking=True)
-    bind_logger(game_id, g_idx, info_s)
+    bind_logger(display_name, g_idx, info_s)
     while not shutdown.is_set():
         while time.time() > next_frame_due:
             next_frame_due += 1.0 / fps
@@ -247,9 +279,20 @@ def env_proc(first_start_at, game_chunk, offset, obs_s, act_s, info_s, shutdown,
     threads = [
         threading.Thread(
             target=env_thread_worker,
-            args=(first_start_at, g, offset + i, obs_s, act_s, info_s, shutdown, fps, max_episode_steps),
+            args=(
+                first_start_at,
+                game_id,
+                display_name,
+                offset + i,
+                obs_s,
+                act_s,
+                info_s,
+                shutdown,
+                fps,
+                max_episode_steps,
+            ),
         )
-        for i, g in enumerate(game_chunk)
+        for i, (game_id, display_name) in enumerate(game_chunk)
     ]
     for t in threads: t.start()
     for t in threads: t.join()
@@ -465,7 +508,7 @@ def _monitor_processes(
 def main(argv: Sequence[str] | None = None) -> None:
     args = parse_args(argv or sys.argv[1:])
 
-    selected_games = resolve_games(args)
+    selected_games, game_display_names = resolve_games(args)
     if not selected_games:
         raise ValueError("No environments selected – specify at least one via --game/--games.")
 
@@ -478,7 +521,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     mp.set_start_method(start_method, force=True)
 
     num_envs = len(selected_games)
-    print(f"Selected {num_envs} environment(s): {', '.join(selected_games)}")
+    print(f"Selected {num_envs} environment(s): {', '.join(game_display_names)}")
     print(f"Using device={device} | start_method={start_method} | fps={args.fps} | max_episode_steps={max_episode_steps}")
 
     obs_s = torch.zeros((num_envs, 250, 160, 3), dtype=torch.uint8, device=device).share_memory_()
@@ -490,10 +533,10 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     num_procs = args.num_procs or min(DEFAULT_NUM_PROCS, num_envs)
     num_procs = max(1, num_procs)
-    # ``np.array_split`` keeps the ordering of ``selected_games`` while distributing
-    # them roughly evenly across worker processes.
-    raw_chunks = np.array_split(selected_games, num_procs)
-    game_chunks: List[List[str]] = [list(chunk) for chunk in raw_chunks if len(chunk) > 0]
+
+    game_instances = list(zip(selected_games, game_display_names))
+    raw_chunks = np.array_split(np.array(game_instances, dtype=object), num_procs)
+    game_chunks: List[List[tuple[str, str]]] = [list(chunk) for chunk in raw_chunks if len(chunk) > 0]
 
     first_start_at = time.time()
     for i, chunk in enumerate(game_chunks):
@@ -507,17 +550,21 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     from bg_record import bg_record_proc
 
-    proc_configs.append({'target': bg_record_proc, 'args': (obs_s, info_s, shutdown, selected_games, first_start_at)})
+    proc_configs.append({'target': bg_record_proc, 'args': (obs_s, info_s, shutdown, game_display_names, first_start_at)})
 
     viewer_args: Optional[tuple] = None
     if args.show_viewer and num_envs:
         if args.viewer_game is not None:
             try:
-                viewer_indices = [selected_games.index(args.viewer_game)]
-            except ValueError as exc:
-                raise ValueError(
-                    f"Requested viewer game '{args.viewer_game}' is not part of the selected game list."
-                ) from exc
+                viewer_index = game_display_names.index(args.viewer_game)
+            except ValueError:
+                try:
+                    viewer_index = selected_games.index(args.viewer_game)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Requested viewer game '{args.viewer_game}' is not part of the selected game list."
+                    ) from exc
+            viewer_indices = [viewer_index]
         elif args.viewer_env_index is not None:
             viewer_index = args.viewer_env_index
             if not (0 <= viewer_index < num_envs):
@@ -527,7 +574,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             viewer_indices = [viewer_index]
         else:
             viewer_indices = list(range(num_envs))
-        viewer_args = (obs_s, shutdown, viewer_indices, selected_games, args.viewer_scale, args.viewer_fps)
+        viewer_args = (obs_s, shutdown, viewer_indices, game_display_names, args.viewer_scale, args.viewer_fps)
 
     procs = [mp.Process(**cfg) for cfg in proc_configs]
 


### PR DESCRIPTION
## Summary
- add a new `--instances-per-game` flag so each selected Atari title can be replicated across multiple environments
- adjust environment worker setup, logging and viewer labelling to track per-instance display names while keeping Gym IDs intact
- document the macOS workflow for tiling multiple parallel instances in the README and extend the flag reference table

## Testing
- python -m py_compile atari_learner.py

------
https://chatgpt.com/codex/tasks/task_e_68d2cd66aed483239ea13e3abceb7b10