### PR TITLE
Adjust exploration schedule for stability

### DIFF
--- a/myagent.py
+++ b/myagent.py
@@ -302,8 +302,8 @@ class Agent:
     MAX_GRAD_NORM = 10.0
     EPSILON_START = 1.0
     EPSILON_FINAL = 0.05
-    EPSILON_DECAY = 75_000
-    UPDATES_PER_STEP = 2
+    EPSILON_DECAY = 150_000
+    UPDATES_PER_STEP = 1
 
     def __init__(self, game_ids: Optional[Sequence[str]] = None, max_snapshots: int = 5) -> None:
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
## Summary
- lengthen the epsilon decay window to slow the exploration annealing
- reduce the number of updates per environment step to limit aggressive training bursts

## Testing
- python -m py_compile myagent.py

------
https://chatgpt.com/codex/tasks/task_e_68d3466156408323895146054795a5ce