### PR TITLE
Tune hyperparameters for faster early learning

### DIFF
--- a/myagent.py
+++ b/myagent.py
@@ -295,15 +295,15 @@ class Agent:
     LEARNING_RATE = 2.5e-4
     REPLAY_CAPACITY = 50_000
     REPLAY_SNAPSHOT_LIMIT = 5_000
-    BATCH_SIZE = 64
+    BATCH_SIZE = 32
     GAMMA = 0.99
-    LEARNING_STARTS = 1_000
-    TARGET_UPDATE_INTERVAL = 2_000
+    LEARNING_STARTS = 300
+    TARGET_UPDATE_INTERVAL = 1_000
     MAX_GRAD_NORM = 10.0
     EPSILON_START = 1.0
-    EPSILON_FINAL = 0.05
-    EPSILON_DECAY = 150_000
-    UPDATES_PER_STEP = 1
+    EPSILON_FINAL = 0.1
+    EPSILON_DECAY = 75_000
+    UPDATES_PER_STEP = 2
 
     def __init__(self, game_ids: Optional[Sequence[str]] = None, max_snapshots: int = 5) -> None:
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
## Summary
- decrease the initial replay warmup and batch size so updates start earlier
- double the update frequency and refresh the target network more often to keep value estimates current
- shorten the exploration schedule with a higher final epsilon for quicker exploitation

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d5ef78c38883239a2cde8be75f30da