### PR TITLE
Add OS-specific setup guides with single-game recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ As of this update the orchestrator can also run on CPU-only systems.  Use `--gam
 
 ## 3. Software Requirements
 
+Looking for platform-specific setup guides?  The `docs/` folder now contains step-by-step READMEs tailored to the major desktop operating systems:
+
+* [Linux instructions](docs/README-linux.md) – Ubuntu-focused guide with GPU-oriented recipes.
+* [macOS instructions](docs/README-macos.md) – Apple Silicon and Intel tips plus MPS-ready commands.
+* [Windows instructions](docs/README-windows.md) – WSL2-first walkthrough with native PowerShell alternatives.
+
+Each guide also enumerates "optimal" single-game commands tuned for the most common hardware configurations on that platform.
+
 | Component | Recommended Version | Notes |
 |-----------|--------------------|-------|
 | Operating system | Linux (Ubuntu 22.04 tested), macOS 14+ | Uses `forkserver` on Linux and automatically falls back to `spawn` on macOS. |

--- a/docs/README-linux.md
+++ b/docs/README-linux.md
@@ -1,0 +1,137 @@
+# AtariLearner on Linux
+
+This guide walks through setting up and running the AtariLearner orchestration script on a modern Linux distribution (Ubuntu 22.04+ tested).  It focuses on reproducible installation steps and high-throughput single-game runs that saturate a local GPU.
+
+## Prerequisites
+
+### Hardware
+
+* **GPU:** NVIDIA RTX 3080/4080/4090-class GPU with at least 12 GB of memory.  Training the full-resolution RGB pipeline for one title comfortably fits in 8–10 GB, leaving headroom for replay buffers and optimiser state.
+* **CPU:** 8+ cores recommended so that environment workers and the learner can run concurrently without contention.
+* **Memory:** 16 GB RAM minimum (32 GB+ suggested if you increase `--instances-per-game`).
+* **Storage:** Only a few GB are needed for checkpoints and ROMs.
+
+### Software
+
+* Ubuntu 22.04 LTS (or similar).  Ensure your kernel and NVIDIA driver are up to date.
+* Python 3.10 or 3.11.
+* CUDA drivers/toolkit matching your GPU (12.1 or 11.8 work with the latest PyTorch wheels).
+* System packages: `build-essential`, `python3-venv`, and `ffmpeg` (optional for video capture).
+
+Install the base packages:
+
+```bash
+sudo apt update
+sudo apt install -y build-essential python3 python3-venv python3-dev ffmpeg
+```
+
+Install the CUDA-enabled PyTorch wheel and Python dependencies inside a virtual environment:
+
+```bash
+cd /path/to/AtariLearner
+python3 -m venv .venv
+source .venv/bin/activate
+
+python -m pip install --upgrade pip wheel setuptools
+# Replace cu121 with the correct CUDA tag for your driver.
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+
+pip install "gymnasium[atari,accept-rom-license]" numpy av pillow
+```
+
+Accept the ROM license prompt the first time Gymnasium loads an Atari environment.  You can pre-download the ROMs with:
+
+```bash
+python -c "import gymnasium as gym; gym.make('ALE/Pong-v5')"
+```
+
+## Environment variables
+
+Set the two environment variables that control seeding and runtime:
+
+```bash
+export myseed=42
+export RUNDURATIONSECONDS=$((30*60))  # 30-minute training session
+```
+
+## Single-game "optimal" run recipes
+
+The goal of single-game optimisation is to maximise sample throughput for one title while keeping GPU utilisation high.  The commands below assume Pong (`ALE/Pong-v5`), but you can substitute any Gymnasium Atari ID.
+
+### 1. High-throughput GPU run (default viewer disabled)
+
+```bash
+python atari_learner.py \
+  --game ALE/Pong-v5 \
+  --device cuda \
+  --num-procs 8 \
+  --instances-per-game 8 \
+  --fps 60
+```
+
+* Uses CUDA tensors for learner + workers.
+* Spawns eight worker processes (enough to feed a 4090-class GPU).
+* Replicates Pong eight times to generate diverse experience.
+
+### 2. GPU run with live viewer
+
+```bash
+python atari_learner.py \
+  --game ALE/Pong-v5 \
+  --device cuda \
+  --num-procs 6 \
+  --instances-per-game 6 \
+  --show-viewer \
+  --viewer-scale 2
+```
+
+* Slightly fewer workers to offset viewer overhead.
+* Opens a Tkinter window showing the first environment.
+
+### 3. CPU-only fallback (headless server)
+
+```bash
+python atari_learner.py \
+  --game ALE/Pong-v5 \
+  --device cpu \
+  --num-procs 4 \
+  --instances-per-game 4 \
+  --fps 30
+```
+
+* Targets systems without a discrete GPU (or during GPU maintenance windows).
+* Lower frame rate keeps CPU load manageable.
+
+### 4. Resume from checkpoint
+
+If `checkpoints/latest.pt` exists, resume training and keep only the last five snapshots:
+
+```bash
+python atari_learner.py \
+  --game ALE/Pong-v5 \
+  --device cuda \
+  --num-procs 8 \
+  --instances-per-game 8 \
+  --checkpoint-dir checkpoints \
+  --max-checkpoint-snapshots 5
+```
+
+### 5. Fresh run ignoring stale checkpoints
+
+```bash
+python atari_learner.py \
+  --game ALE/Pong-v5 \
+  --device cuda \
+  --num-procs 8 \
+  --instances-per-game 8 \
+  --fresh-agent
+```
+
+## Monitoring tips
+
+* Use `nvidia-smi dmon` to confirm the GPU is saturated (target 90%+ utilisation).
+* Sample CPU usage with `htop`—if workers are starved, reduce `--num-procs` or `--instances-per-game`.
+* Check `checkpoints/` for `latest.pt` snapshots every few minutes; adjust `--checkpoint-interval` if needed.
+* When running with `--show-viewer`, keep the Tkinter window on the same X server or Wayland session—X forwarding adds latency.
+
+Happy training!

--- a/docs/README-macos.md
+++ b/docs/README-macos.md
@@ -1,0 +1,131 @@
+# AtariLearner on macOS
+
+This guide describes how to run AtariLearner on macOS Ventura/Sonoma for both Apple Silicon (M1/M2/M3) and Intel Macs.  Because macOS lacks native CUDA, the runner falls back to CPU or Apple's Metal Performance Shaders (MPS) backend when available.
+
+## Prerequisites
+
+### Hardware
+
+* **Apple Silicon:** M1 Pro/Max, M2 Pro/Max, or M3-class chips perform best thanks to the integrated GPU and unified memory.
+* **Intel:** Preferably with a discrete AMD GPU (Metal-enabled) and at least 32 GB RAM.  CPU-only runs work but will be slower.
+* **Memory:** 16 GB RAM minimum; unified memory benefits from higher capacity if you increase `--instances-per-game`.
+
+### Software
+
+* macOS 13 (Ventura) or newer.
+* Xcode command-line tools (`xcode-select --install`).
+* Homebrew (recommended) for installing FFmpeg.
+* Python 3.10 or 3.11 from the system, Homebrew, or `pyenv`.
+
+Create and activate a virtual environment:
+
+```bash
+cd /path/to/AtariLearner
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip wheel setuptools
+```
+
+Install the universal PyTorch build (includes CPU + Metal support), Gymnasium, and dependencies:
+
+```bash
+pip install torch torchvision
+pip install "gymnasium[atari,accept-rom-license]" numpy av pillow
+```
+
+Optional: install FFmpeg via Homebrew for the sample recorder module:
+
+```bash
+brew install ffmpeg
+```
+
+Accept the ROM licence prompt once with:
+
+```bash
+python -c "import gymnasium as gym; gym.make('ALE/Pong-v5')"
+```
+
+## Environment variables
+
+```bash
+export myseed=7
+export RUNDURATIONSECONDS=$((20*60))  # 20-minute experiment for laptops
+```
+
+## Single-game run recipes
+
+macOS defaults to the safe `spawn` multiprocessing start method.  The commands below balance throughput with thermals on Apple Silicon laptops.  Substitute your preferred game ID for Pong.
+
+### 1. Apple Silicon with MPS acceleration
+
+```bash
+python atari_learner.py \
+  --game ALE/Pong-v5 \
+  --device auto \
+  --num-procs 4 \
+  --instances-per-game 4 \
+  --fps 45
+```
+
+* `--device auto` selects the Metal backend when available.
+* Four workers keep the SoC busy without overwhelming cooling.
+
+### 2. CPU-only run (Intel Mac or thermally constrained laptop)
+
+```bash
+python atari_learner.py \
+  --game ALE/Pong-v5 \
+  --device cpu \
+  --num-procs 2 \
+  --instances-per-game 2 \
+  --fps 30
+```
+
+* Keeps the process count low to avoid fan spikes.
+
+### 3. High-visibility training with viewer
+
+```bash
+python atari_learner.py \
+  --game ALE/Pong-v5 \
+  --device auto \
+  --num-procs 3 \
+  --instances-per-game 3 \
+  --show-viewer \
+  --viewer-scale 2 \
+  --viewer-fps 20
+```
+
+* Reduces viewer FPS to minimise UI overhead.
+
+### 4. Resume from checkpoint stored on external drive
+
+```bash
+python atari_learner.py \
+  --game ALE/Pong-v5 \
+  --device auto \
+  --num-procs 4 \
+  --instances-per-game 4 \
+  --checkpoint-dir /Volumes/External/checkpoints \
+  --max-checkpoint-snapshots 3
+```
+
+### 5. Fresh run bypassing checkpoints
+
+```bash
+python atari_learner.py \
+  --game ALE/Pong-v5 \
+  --device auto \
+  --num-procs 4 \
+  --instances-per-game 4 \
+  --fresh-agent
+```
+
+## Tips
+
+* macOS Ventura+ prompts for microphone/camera access when Tkinter windows capture input—deny safely.
+* Use `Activity Monitor` or `powermetrics --samplers smc` to monitor GPU usage and thermals.
+* If you see "NotImplementedError: MPS backend is not available", reinstall PyTorch (ensure you are on Python 3.10/3.11) and update macOS.
+* The first run after waking from sleep can be sluggish; restart the terminal session to reset the MPS context if needed.
+
+Happy training on macOS!

--- a/docs/README-windows.md
+++ b/docs/README-windows.md
@@ -1,0 +1,207 @@
+# AtariLearner on Windows
+
+This document explains how to run AtariLearner on Windows 11 using either WSL2 (recommended for CUDA workflows) or native Windows Python environments.  WSL2 provides the smoothest experience because the repository targets a Unix-style process model.
+
+## Option A – WSL2 with Ubuntu (recommended)
+
+### Prerequisites
+
+* Windows 11 22H2 or later.
+* NVIDIA GPU with drivers that support WSL2 CUDA (version 522+).
+* Installed WSL2 with Ubuntu 22.04: `wsl --install -d Ubuntu`.
+* Windows Terminal (optional but convenient).
+
+Inside the Ubuntu shell:
+
+```bash
+sudo apt update
+sudo apt install -y build-essential python3 python3-venv python3-dev ffmpeg
+```
+
+Create and activate a Python virtual environment in the cloned repository:
+
+```bash
+cd /mnt/c/Users/<you>/AtariLearner
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip wheel setuptools
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+pip install "gymnasium[atari,accept-rom-license]" numpy av pillow
+```
+
+Accept the Atari ROM licence once:
+
+```bash
+python -c "import gymnasium as gym; gym.make('ALE/Pong-v5')"
+```
+
+Set up environment variables (place them in `~/.bashrc` or export per-session):
+
+```bash
+export myseed=101
+export RUNDURATIONSECONDS=$((45*60))
+```
+
+### Single-game run recipes (WSL2)
+
+1. **Max throughput on a 4090:**
+
+   ```bash
+   python atari_learner.py \
+     --game ALE/Pong-v5 \
+     --device cuda \
+     --num-procs 8 \
+     --instances-per-game 10 \
+     --fps 60
+   ```
+
+2. **Viewer-enabled session:**
+
+   ```bash
+   python atari_learner.py \
+     --game ALE/Pong-v5 \
+     --device cuda \
+     --num-procs 6 \
+     --instances-per-game 6 \
+     --show-viewer \
+     --viewer-scale 2
+   ```
+
+3. **CPU-only fallback (no CUDA pass-through):**
+
+   ```bash
+   python atari_learner.py \
+     --game ALE/Pong-v5 \
+     --device cpu \
+     --num-procs 4 \
+     --instances-per-game 4 \
+     --fps 30
+   ```
+
+4. **Resume from checkpoints stored on the Windows filesystem:**
+
+   ```bash
+   python atari_learner.py \
+     --game ALE/Pong-v5 \
+     --device cuda \
+     --num-procs 8 \
+     --instances-per-game 10 \
+     --checkpoint-dir /mnt/c/Users/<you>/AtariLearner/checkpoints \
+     --max-checkpoint-snapshots 5
+   ```
+
+5. **Fresh start ignoring checkpoints:**
+
+   ```bash
+   python atari_learner.py \
+     --game ALE/Pong-v5 \
+     --device cuda \
+     --num-procs 8 \
+     --instances-per-game 10 \
+     --fresh-agent
+   ```
+
+## Option B – Native Windows Python (experimental)
+
+Running the orchestrator directly on Windows is possible but carries caveats because the default multiprocessing start method is `spawn`.  Expect slower start-up times and ensure your agent/background recorder is import-safe.
+
+### Prerequisites
+
+* Install Python 3.10+ from the Microsoft Store or python.org.
+* Install the Visual Studio 2022 Build Tools (C++ workload) for compiling dependencies.
+* Install the latest NVIDIA drivers.
+* Optional: install Chocolatey and use it to fetch FFmpeg (`choco install ffmpeg`).
+
+Open **Windows Terminal → PowerShell** and create a virtual environment:
+
+```powershell
+cd C:\path\to\AtariLearner
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip wheel setuptools
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+pip install "gymnasium[atari,accept-rom-license]" numpy av pillow
+```
+
+Export environment variables for the current PowerShell session:
+
+```powershell
+$env:myseed = 2024
+$env:RUNDURATIONSECONDS = 3600
+```
+
+Because Gymnasium downloads ROMs on first use, trigger the prompt once:
+
+```powershell
+python -c "import gymnasium as gym; gym.make('ALE/Pong-v5')"
+```
+
+### Single-game commands (native Windows)
+
+Use escaped quotes and backticks to wrap long commands if desired.  Below are PowerShell-friendly snippets.
+
+1. **Maximum CUDA throughput:**
+
+   ```powershell
+   python atari_learner.py `
+     --game ALE/Pong-v5 `
+     --device cuda `
+     --num-procs 6 `
+     --instances-per-game 8 `
+     --fps 60
+   ```
+
+2. **Viewer-enabled training:**
+
+   ```powershell
+   python atari_learner.py `
+     --game ALE/Pong-v5 `
+     --device cuda `
+     --num-procs 4 `
+     --instances-per-game 4 `
+     --show-viewer `
+     --viewer-scale 2
+   ```
+
+3. **CPU-only mode (for systems without CUDA):**
+
+   ```powershell
+   python atari_learner.py `
+     --game ALE/Pong-v5 `
+     --device cpu `
+     --num-procs 3 `
+     --instances-per-game 3 `
+     --fps 30
+   ```
+
+4. **Resume from checkpoints:**
+
+   ```powershell
+   python atari_learner.py `
+     --game ALE/Pong-v5 `
+     --device cuda `
+     --num-procs 6 `
+     --instances-per-game 8 `
+     --checkpoint-dir checkpoints `
+     --max-checkpoint-snapshots 5
+   ```
+
+5. **Force fresh agent:**
+
+   ```powershell
+   python atari_learner.py `
+     --game ALE/Pong-v5 `
+     --device cuda `
+     --num-procs 6 `
+     --instances-per-game 8 `
+     --fresh-agent
+   ```
+
+## Troubleshooting
+
+* If PowerShell blocks scripts, run `Set-ExecutionPolicy -Scope Process RemoteSigned` before activating the virtual environment.
+* When running inside WSL2, ensure the project folder resides on the Linux filesystem (e.g. `~/AtariLearner`) for best disk performance.
+* `ModuleNotFoundError: tkinter`: install `sudo apt install python3-tk` inside WSL2 or add the Windows optional feature "Tkinter" when using the Windows Store Python distribution.
+* If FFmpeg is missing, either install it via `apt` (WSL2) or Chocolatey (Windows), or provide a no-op `bg_record.py`.
+
+Happy training on Windows!


### PR DESCRIPTION
## Summary
- add Linux, macOS, and Windows specific READMEs under docs/ with optimal single-game training commands
- link the new operating-system guides from the main README software requirements section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5f22fe8708323a01603977bea7c5b