### PR TITLE
Fix atarilearner script runtime error

### DIFF
--- a/atari_learner.py
+++ b/atari_learner.py
@@ -352,6 +352,7 @@ def agent_proc(
     max_snapshots,
     fresh_agent,
     tensorboard_log,
+    device,
 ):
     seed('agent', 0)
     from myagent import Agent
@@ -375,6 +376,7 @@ def agent_proc(
         max_snapshots=max_snapshots,
         log_dir=tensorboard_log,
         checkpoint_dir=checkpoint_dir,
+        device=device,
     )
     agent.configure_envs(game_ids)
 
@@ -745,6 +747,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                 int(args.max_checkpoint_snapshots),
                 bool(args.fresh_agent),
                 args.tensorboard_log,
+                device.type,  # Pass resolved device type to ensure consistency
             ),
         }
     ]

--- a/myagent.py
+++ b/myagent.py
@@ -413,8 +413,9 @@ class Agent:
         max_snapshots: int = 5,
         log_dir: Optional[str] = None,
         checkpoint_dir: str = "checkpoints",
+        device: str = "auto",
     ) -> None:
-        self.device = _get_device("auto")
+        self.device = _get_device(device)
         print(f"[Agent] Using device: {self.device}")
 
         self.checkpoint_dir = checkpoint_dir


### PR DESCRIPTION
When running with --device cpu on Apple Silicon, the Agent class was independently selecting MPS via _get_device("auto"), causing a device mismatch between the shared memory tensors (CPU) and agent operations (MPS). This resulted in memory corruption manifesting as malloc errors: "Incorrect checksum for freed object... probably modified after being freed"

The fix propagates the resolved device type from the main process through agent_proc to the Agent constructor, ensuring all components use the same device.